### PR TITLE
User delivery spot preference & automatic selection of it in the order form

### DIFF
--- a/open-csa-wp-orders.php
+++ b/open-csa-wp-orders.php
@@ -9,11 +9,23 @@ function open_csa_wp_show_order_form ($user_id, $spot_id, $delivery_id, $display
 	wp_enqueue_style('jquery.cluetip.style');
 	
 	global $wpdb;
-	
+	$csa_data = null;
+	$spot_id_preference = null;	
+
+	//If it is a personal order, fetch the meta data of the user. Update spot_id with the information from the meta data(Maybe wrong but let's roll with it now)
+	if ($personal_order === true)	{
+		$csa_data = get_user_meta( $user_id, 'open-csa-wp_user', true );
+		if (isset($csa_data['spot']))
+			$spot_id_preference = $csa_data['spot'];
+	}
+
+	//Apo pou erxetai to spot_id?!?! Mporei na erthei apo kapou??? Psajimo
 	if ($spot_id != null) {
 		$spot_info = $wpdb->get_results($wpdb->prepare("SELECT * FROM ". OPEN_CSA_WP_TABLE_SPOTS ." WHERE id=%d", $spot_id))[0];	
 	}
 	
+
+
 	$edit_order_bool = false;
 	$header_text = __("Submit New Order", OPEN_CSA_WP_DOMAIN);
 	if (isset($_POST["open-csa-wp-showEditableUserOrderForm_user_input"]) OR (
@@ -79,19 +91,32 @@ function open_csa_wp_show_order_form ($user_id, $spot_id, $delivery_id, $display
 				
 				<tr valign="top"
 				<?php 
-					if ($user_id == null) {
+					if ($user_id === null) {
 						echo "style = 'display:none'";
 					}
 				?>
 				>
 				<td>
+					<!-- Here starts the creation of the select element regarding the delivery spot -->
 					<select
 						name = 'open-csa-wp-showSelectSpotForm_spot_input'
+						<?php //---[By eliminating this code we can provide to the user the choice to select another delivery spot instead of his prefered one.]---
+							//If there is a delivery spot preference, select the default message
+							if ($spot_id_preference !== null) {
+								echo 'disabled="disabled" ';
+							} 
+						?>
 						onchange = 'getElementById("open-csa-wp-showNewOrderForm_form_id").submit();'
+						
 					>
 						<option 
 							value="" 
-							selected="selected" 
+							<?php 
+								//If a spot_id is not present, select the default message
+								if ($spot_id === null && $spot_id_preference === null) {
+									echo 'selected="selected" ';
+								} 
+							?>
 							disabled="disabled"
 						> 
 						<?php
@@ -103,7 +128,13 @@ function open_csa_wp_show_order_form ($user_id, $spot_id, $delivery_id, $display
 						?>
 						
 						</option>
-						<?php open_csa_wp_select_delivery_spots($spot_id, __("on delivery spot",OPEN_CSA_WP_DOMAIN).": ");?>
+						<!-- Populate the options by calling the function 'open_csa_wp_select_delivery_spots',
+						     provide delivery spot preference(if present) if a spot_id is not provided-->
+						<?php 	
+							if($spot_id === null && $spot_id_preference !== null)
+								$spot_id = $spot_id_preference;
+							open_csa_wp_select_delivery_spots($spot_id, __("on delivery spot",OPEN_CSA_WP_DOMAIN).": ");
+						?>
 					</select>
 				</td>
 				</tr>

--- a/open-csa-wp-spots.php
+++ b/open-csa-wp-spots.php
@@ -930,17 +930,21 @@ function open_csa_wp_delivery_spots_exist ($personal_order){
 	else return true;	
 }
 
+//Function: open_csa_wp_select_delivery_spots
+//Args: $selected_spot_id <-- a delivery spot id or null
+//      $message <-- A sting to be added to the given spot id option
+//Descr: Populates a select element using the delivery spots in the database as options. 
+//	 If a spot id is provided, it marks as selected and adds a message before the spot name.
 function open_csa_wp_select_delivery_spots($selected_spot_id, $message) {
 	global $wpdb;
 	$deliverySpots = $wpdb->get_results("SELECT id,spot_name FROM ".OPEN_CSA_WP_TABLE_SPOTS." WHERE is_delivery_spot=1");
 	
 	foreach ($deliverySpots as $delivery_spot_id) {
-		if ($delivery_spot_id->id == $selected_spot_id) 								
+		if ($selected_spot_id !== null && $delivery_spot_id->id === $selected_spot_id) 								
 			echo "<option value='".$delivery_spot_id->id."' selected='selected' style='color:black'>". $message. $delivery_spot_id->spot_name ."</option>";
 		else
 			echo "<option value='".$delivery_spot_id->id."' style='color:black'>". $delivery_spot_id->spot_name ."</option>";
 	}
 }
-
 
 ?>

--- a/open-csa-wp-users.php
+++ b/open-csa-wp-users.php
@@ -74,9 +74,11 @@ function open_csa_wp_edit_user_properties ($user, $new_user) {
 	wp_enqueue_style('jquery.cluetip.style');
 
 	$csa_data = array();
+	$spot_id_preference = null;
 
 	if (!$new_user)	{
 		$csa_data = get_user_meta( $user->ID, 'open-csa-wp_user', true );
+
 	}
     ?>
 	<h3><?php _e('CSA Properties',OPEN_CSA_WP_DOMAIN); ?></h3>
@@ -224,6 +226,38 @@ function open_csa_wp_edit_user_properties ($user, $new_user) {
 				> <label for="open-csa-wp-administrator_radio"><?php _e('Administrator',OPEN_CSA_WP_DOMAIN);?></label>
 			</td>
 		</tr>
+		<tr>
+			<!-- Here starts the creation of the select element regarding the prefered delivery spot -->
+			<th><?php _e('Delivery Spot Preference',OPEN_CSA_WP_DOMAIN); ?></th>
+			<td>
+				<select
+					id = 'open-csa-wp_user_spot_preference'
+					name = 'open-csa-wp_user_spot_preference'
+				>
+					<option 
+						value = ""
+						<?php 
+							//If we are about to add a new user or we are reviewing a user without a set delivery spot, select the default message
+							if ($new_user || !isset($csa_data['spot'])) {
+								echo 'selected="selected" ';
+							} 
+						?>
+						disabled="disabled"
+					> 
+						<?php
+							_e("select the delivery spot ...",OPEN_CSA_WP_DOMAIN);
+						?>
+					</option>
+					<!-- Populate the options by calling the function 'open_csa_wp_select_delivery_spots', provide delivery spot preference if it is already set-->
+					<?php 
+						if ($selected_csa_data != null && isset($selected_csa_data['spot']))
+							$spot_id_preference = $selected_csa_data['spot'];
+						open_csa_wp_select_delivery_spots($spot_id_preference, '');
+					?>
+				</select>
+
+			</td>
+		</tr>
 	</table>
 <?php
 }
@@ -251,6 +285,10 @@ function open_csa_wp_save_user_properties( $user_id ) {
 		
 	if(!empty( $_POST['open-csa-wp_user_role'] ))	{
 		$csa_data['role'] = sanitize_text_field( $_POST['open-csa-wp_user_role'] );
+	}
+
+	if(!empty( $_POST['open-csa-wp_user_spot_preference'] ))	{
+		$csa_data['spot'] = sanitize_text_field( $_POST['open-csa-wp_user_spot_preference'] );
 	}
 	
 	if(!empty($csa_data)) {


### PR DESCRIPTION
Added:
- Select delivery spot preference when adding a user and add it to his meta data.[Admin only]
- Delivery spot preference is shown and can be changed when editting an existing user, this works even if he didn't have a preference selected before or
  even if this information was never set in his meta data(e.g. old users, registered before this change).[Admin only]
- When a user does a personal order, if his prefered delivery spot is set, then the delivery spot is automatically selected and shown to him in the select
  element. The select element is disabled therefore he cannot choose another when submitting an order. Only the administrator can change the preference by
  editting the user's account, this is also the case for the admin. If there is no prefered delivery spot selected, then the user can select from the drop
  down list.[All users]
- Description of the 'open_csa_wp_select_delivery_spots' function (file: open-csa-wp-spots.php line: 938).
- Some comments here and there along my changes.
